### PR TITLE
Don't clobber other filters put onto the query loop

### DIFF
--- a/includes/class-taxonomy-query-filter.php
+++ b/includes/class-taxonomy-query-filter.php
@@ -197,18 +197,20 @@ if (!class_exists('Twenty_Bellows_Query_Filter')) {
 
 			add_filter('query_loop_block_query_vars', function ($query) use ($term_slug, $taxonomy_slug) {
 
+				$query['tax_query'] = $query['tax_query'] ?? [];
+
 				if ($term_slug === 'all' || $term_slug === null) {
-					$query['tax_query'] =[[
+					$query['tax_query'][] = [
 						'taxonomy' => $taxonomy_slug,
 						'operator' => 'EXISTS',
-					]];
+					];
 				}
 				else {
-					$query['tax_query'] = [[
+					$query['tax_query'][] = [
 						'taxonomy' => $taxonomy_slug,
 						'field'    => 'slug',
 						'terms'    => $term_slug,
-					]];
+					];
 				}
 				return $query;
 			});


### PR DESCRIPTION
This pull request makes a targeted improvement to the way taxonomy queries are constructed in the `pre_render_query_block` method. The main change ensures that multiple taxonomy queries can be appended correctly, rather than overwriting previous queries.